### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When a user on your BBS chooses to connect to DoorParty:
 			* The user may have several DoorParty accounts, one for each BBS they connect from; they cannot use the same DoorParty account from multiple BBSs
 
 On Mystic, for example, this is menu command `IR`, with a `DATA` field like:
-* `/ADDR=localhost:9999 /USER=[system_tag]@USER@ /PASS=some_password`
-	* Mind that `system_tag` and `some_password` must be replaced with your own values
+* `/ADDR=localhost:9999 /USER=@USER@ /PASS=some_password`
+	* Mind that `some_password` must be replaced with your own values
 
 A [script](third_party/synchronet/doorparty.js) and [instructions for Synchronet](third_party/synchronet/) are available [here](third_party/synchronet/).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ If you use some other init system, you're on your own - but feel free to share y
 ### Windows
 
 I dunno, put a shortcut in your Startup menu or some shit like that.
+
+### Docker
+
+```
+docker run -d \
+  --restart=unless-stopped \
+  -p 9999:9999 \
+  -e SYSTEM_TAG=[???] \
+  -e SSH_USERNAME=YOURUSER \
+  -e SSH_PASSWORD=YOURPASS \
+  -e LOCAL_PORT=9999 \
+  bbsio/doorparty:latest
+```
+
+You can also build this project yourself.
+
+```
+docker build -f build/package/Dockerfile -t bbsio/doorparty .
+```
+
 	
 ## Usage
 


### PR DESCRIPTION
Add docker instructions.  Removed the `system_tag` from the Mystic instructions since the connector adds it directly.

I did specify the LOCAL_PORT environment variable.. this should only be needed until this version is built/pushed to Dockerhub.